### PR TITLE
Handle Facebook logins without email

### DIFF
--- a/helsso/urls.py
+++ b/helsso/urls.py
@@ -25,6 +25,8 @@ def show_login(request):
 urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
     url(r'^accounts/profile/', show_login),
+    url(r'^accounts/login/', LoginView.as_view()),
+    url(r'^accounts/logout/', LogoutView.as_view()),
     url(r'^accounts/', include(allauth.urls)),
     url(r'^oauth2/applications/', permission_denied),
     url(r'^oauth2/', include(oauth2_provider.urls, namespace='oauth2_provider')),

--- a/helsso/urls.py
+++ b/helsso/urls.py
@@ -1,3 +1,5 @@
+import allauth.urls
+import oauth2_provider.urls
 from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
@@ -23,9 +25,9 @@ def show_login(request):
 urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
     url(r'^accounts/profile/', show_login),
-    url(r'^accounts/', include('allauth.urls')),
+    url(r'^accounts/', include(allauth.urls)),
     url(r'^oauth2/applications/', permission_denied),
-    url(r'^oauth2/', include('oauth2_provider.urls', namespace='oauth2_provider')),
+    url(r'^oauth2/', include(oauth2_provider.urls, namespace='oauth2_provider')),
     url(r'^user/(?P<username>[\w.@+-]+)/?$', UserView.as_view()),
     url(r'^user/$', UserView.as_view()),
     url(r'^jwt-token/$', GetJWTView.as_view()),

--- a/helsso/urls.py
+++ b/helsso/urls.py
@@ -5,7 +5,7 @@ from django.http import HttpResponse
 from django.contrib.staticfiles import views as static_views
 from django.views.defaults import permission_denied
 from .api import UserView, GetJWTView
-from users.views import LoginView, LogoutView
+from users.views import EmailNeededView, LoginView, LogoutView
 
 
 def show_login(request):
@@ -28,7 +28,8 @@ urlpatterns = [
     url(r'^user/$', UserView.as_view()),
     url(r'^jwt-token/$', GetJWTView.as_view()),
     url(r'^login/$', LoginView.as_view()),
-    url(r'^logout/$', LogoutView.as_view())
+    url(r'^logout/$', LogoutView.as_view()),
+    url(r'^email-needed/$', EmailNeededView.as_view(), name='email_needed'),
 ]
 
 if settings.DEBUG:

--- a/helsso/urls.py
+++ b/helsso/urls.py
@@ -1,11 +1,13 @@
 from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
-from django.http import HttpResponse
 from django.contrib.staticfiles import views as static_views
+from django.http import HttpResponse
 from django.views.defaults import permission_denied
-from .api import UserView, GetJWTView
+
 from users.views import EmailNeededView, LoginView, LogoutView
+
+from .api import GetJWTView, UserView
 
 
 def show_login(request):

--- a/users/templates/email_needed.html
+++ b/users/templates/email_needed.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+
+{% block title %}Sähköposti tarvitaan{% endblock %}
+
+{% block content %}
+<p>
+    Palvelu vaatii sähköpostiosoitteen. Annathan luvan
+    sähköpostiosoitteen välittämiseen Helsingin kertakirjautumiselle.
+</p>
+
+<a href="{{reauth_uri}}">Kirjaudu uudestaan</a>
+{% endblock %}

--- a/users/views.py
+++ b/users/views.py
@@ -76,3 +76,15 @@ class LogoutView(TemplateView):
         if url and re.match(r'http[s]?://', url):
             return redirect(url)
         return super(LogoutView, self).get(*args, **kwargs)
+
+
+class EmailNeededView(TemplateView):
+    template_name = 'email_needed.html'
+
+    def get_context_data(self, **kwargs):
+        context = super(EmailNeededView, self).get_context_data(**kwargs)
+        reauth_uri = self.request.GET.get('reauth_uri', '')
+        if '//' in reauth_uri:  # Prevent open redirect
+            reauth_uri = ''
+        context['reauth_uri'] = reauth_uri
+        return context


### PR DESCRIPTION
If user didn't give a consent for passing e-mail address from Facebook
to Helsso, show a notice that e-mail is really needed and try again.  If
user still doesn't give the e-mail address, redirect to login cancelled
view.

Fixes #12