### PR TITLE
Preserve state on Facebook rerequests

### DIFF
--- a/users/adapter.py
+++ b/users/adapter.py
@@ -76,8 +76,17 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
 def handle_facebook_without_email(sociallogin):
     if 'rerequest' not in sociallogin.state['auth_params']:
         login_uri = reverse('facebook_login')
-        auth_params = urlencode({'auth_params': 'auth_type=rerequest'})
-        get_params = urlencode({'reauth_uri': login_uri + '?' + auth_params})
+
+        # Preserve state otherwise, but override auth_params to pass in
+        # "auth_type=rerequest".  This should ensure that login process
+        # will continue correctly (with correct next URL, scope etc.)
+        # after the rerequest.
+        state = dict(sociallogin.state)
+        state['auth_params'] = 'auth_type=rerequest'
+
+        # Pass state via GET parameters
+        state_params = urlencode(state)
+        get_params = urlencode({'reauth_uri': login_uri + '?' + state_params})
         redirect_to = reverse('email_needed') + '?' + get_params
     else:
         redirect_to = reverse('socialaccount_login_cancelled')


### PR DESCRIPTION
When Facebook login needs to rerequest the consent for e-mail address
(the feature implemented in commit 24e106c) we used to forget all state
of the login process.  This caused the login to not redirect back to
correct URL after successfully given consent for the e-mail address.

Fix this by preserving the state by passing it as a GET parameter.