### PR TITLE
Automatically link via ADFS provided email

### DIFF
--- a/helsso/settings.py
+++ b/helsso/settings.py
@@ -218,6 +218,11 @@ ACCOUNT_LOGOUT_ON_GET = True
 SOCIALACCOUNT_ADAPTER = 'users.adapter.SocialAccountAdapter'
 ACCOUNT_UNIQUE_EMAIL = True
 
+TRUSTED_SOCIALLOGIN_PROVIDERS = [
+    'helsinki_adfs',
+    'espoo_adfs',
+]
+
 SOCIALACCOUNT_PROVIDERS = {
     'facebook': {
         'SCOPE': ['email', 'public_profile'],


### PR DESCRIPTION
When users logs in via either of the ADFS providers and the email
address provided by the ADFS provider is already in use, do one of
these:

  * (1) link the new social accounts to the old user, or
  * (2) remove the email address from the old user.

Linking (1) is done when the existing email address is verified and
removing (2) is done when the existing email address is not verified.

Also add some docstrings and do small refactoring for related SAML
account linking code.